### PR TITLE
fix undo historical scores

### DIFF
--- a/source/model/PadelMatch.mc
+++ b/source/model/PadelMatch.mc
@@ -6,8 +6,6 @@ class PadelMatch {
     private var superTie;
     private var goldenPoint;
 
-    private var historicalScores;
-
     private var matchStatus;
 
     private var prevMatchStatus;
@@ -20,8 +18,6 @@ class PadelMatch {
 
         matchStatus = MatchStatus.New();
         prevMatchStatus = MatchStatus.New();
-
-        historicalScores = [];
     }
 
     // returns a boolean indicating wether the match has ended.
@@ -192,11 +188,10 @@ class PadelMatch {
         return self.matchStatus.copy();
     }
 
-    function getHistoricalScores() {
-        var res = [];
-        res.addAll(self.historicalScores);
+    function getHistoricalScores() as Lang.Array<Lang.String> {
+        var res = self.matchStatus.getHistoricalScores();
 
-        if (self.matchStatus.getP1Games() != 0 || self.matchStatus.getP2Games() != 0) {
+         if (self.matchStatus.getP1Games() != 0 || self.matchStatus.getP2Games() != 0) {
             res.add("" + self.matchStatus.getP1Games() + "-" + self.matchStatus.getP2Games());
         }
 
@@ -225,7 +220,7 @@ class PadelMatch {
 
     function finishSuperTie() as Boolean {
         var result = "" + self.matchStatus.getP1TieScore() + "-" + self.matchStatus.getP2TieScore();
-        self.historicalScores.add(result);
+        self.matchStatus.addHistoricalScore(result);
         return true;
     } 
 
@@ -235,7 +230,7 @@ class PadelMatch {
             result += " (" + self.min(self.matchStatus.getP1TieScore(), self.matchStatus.getP2TieScore()) + ")";
         }
 
-        self.historicalScores.add(result);
+        self.matchStatus.addHistoricalScore(result);
 
         self.matchStatus.resetGames();
 

--- a/source/model/matchStatus.mc
+++ b/source/model/matchStatus.mc
@@ -1,3 +1,5 @@
+import Toybox.Lang;
+
 class MatchStatus {
 
     static const AVAILABLE_POINTS = [0, 15, 30, 40, 'A'];
@@ -14,11 +16,14 @@ class MatchStatus {
     private var p1TieBreakScore;
     private var p2TieBreakScore;
 
+    private var historicalScores;
+
+
     static function New() {
-        return new MatchStatus(0,0,0,0,0,0,0,0);
+        return new MatchStatus(0,0,0,0,0,0,0,0, []);
     }
 
-    function initialize(p1Sets, p2Sets, p1Games, p2Games, p1ScoreIdx, p2ScoreIdx, p1TieBreakScore, p2TieBreakScore) {
+    function initialize(p1Sets, p2Sets, p1Games, p2Games, p1ScoreIdx, p2ScoreIdx, p1TieBreakScore, p2TieBreakScore, historicalScores) {
         self.p1Sets = p1Sets;
         self.p2Sets = p2Sets;
 
@@ -30,6 +35,8 @@ class MatchStatus {
 
         self.p1TieBreakScore = p1TieBreakScore;
         self.p2TieBreakScore = p2TieBreakScore;
+
+        self.historicalScores = historicalScores;
      }
 
 
@@ -97,6 +104,16 @@ class MatchStatus {
         self.p2TieBreakScore++;
     }
 
+    function getHistoricalScores() as Lang.Array<Lang.String> {
+        var res = [];
+        res.addAll(self.historicalScores);
+        return res;
+    }
+
+    function addHistoricalScore(result) {
+        self.historicalScores.add(result);
+    }
+
     function setDeuce() {
         self.p1ScoreIdx = 3;
         self.p2ScoreIdx = 3;
@@ -116,6 +133,8 @@ class MatchStatus {
     }
 
     function copy() as MatchStatus {
-        return new MatchStatus(p1Sets, p2Sets, p1Games, p2Games, p1ScoreIdx, p2ScoreIdx, p1TieBreakScore, p2TieBreakScore);
+        var newHistory = [];
+        newHistory.addAll(self.historicalScores);
+        return new MatchStatus(p1Sets, p2Sets, p1Games, p2Games, p1ScoreIdx, p2ScoreIdx, p1TieBreakScore, p2TieBreakScore, newHistory);
     }
 }

--- a/source/tests/testSuperTie.mc
+++ b/source/tests/testSuperTie.mc
@@ -175,8 +175,6 @@ function superTieFinishTest(logger as Logger) as Boolean {
 
     var status = match.getMatchStatus();
         
-    logger.debug(printMatchStatus(status));
-
     return 
         res == true && // true means game over
         status.getP1Sets() == 2 &&

--- a/source/tests/testUndoMatch.mc
+++ b/source/tests/testUndoMatch.mc
@@ -156,7 +156,14 @@ function undoAfterSetTest(logger as Logger) as Boolean {
 
     var status = match.getMatchStatus();
 
+    var history = match.getHistoricalScores();
+    logger.debug(history);
+
+    Test.assert(history.size == 2);
+
     return 
+        history.size == 1 &&
+        history[0] == "5-2" &&
         status.getP1Sets() == 0 &&
         status.getP2Sets() == 0 &&
         status.getP1Games() == 5 &&

--- a/source/tests/testUndoMatch.mc
+++ b/source/tests/testUndoMatch.mc
@@ -155,15 +155,14 @@ function undoAfterSetTest(logger as Logger) as Boolean {
     match.undo();
 
     var status = match.getMatchStatus();
-
     var history = match.getHistoricalScores();
-    logger.debug(history);
 
-    Test.assert(history.size == 2);
+    Test.assert(history.size() == 1);
+    Test.assert(history[0].equals("5-2"));
 
     return 
-        history.size == 1 &&
-        history[0] == "5-2" &&
+        history.size() == 1 &&
+        history[0].equals("5-2") &&
         status.getP1Sets() == 0 &&
         status.getP2Sets() == 0 &&
         status.getP1Games() == 5 &&

--- a/source/tests/testingUtils.mc
+++ b/source/tests/testingUtils.mc
@@ -26,8 +26,6 @@ function incMatch(
         // FIXME implement and add better API methods
 }
 
-
-
 function printMatchStatus(status as MatchStatus) as String {
 
     return 

--- a/source/tests/testingUtils.mc
+++ b/source/tests/testingUtils.mc
@@ -36,5 +36,6 @@ function printMatchStatus(status as MatchStatus) as String {
     ",P1Score=" + status.getP1Score() + 
     ",P2Score=" + status.getP2Score() + 
     ",P1TieScore=" + status.getP1TieScore() + 
-    ",P2TieScore=" + status.getP2TieScore();
+    ",P2TieScore=" + status.getP2TieScore() +
+    ",history=" + status.getHistoricalScores();
 }


### PR DESCRIPTION
closes #97 

moves historical score to be part of matchStatus. this allows easy revert when undoing