### PR TITLE
migrate to menu2

### DIFF
--- a/resources/menus/golden_point.xml
+++ b/resources/menus/golden_point.xml
@@ -1,4 +1,0 @@
-<menu id="GoldenPointMenu" title="Score">
-    <menu-item id="golden_point_yes" label="Golden Point" />
-    <menu-item id="golden_point_no" label="Advantages" />
-</menu>

--- a/resources/menus/number_of_sets.xml
+++ b/resources/menus/number_of_sets.xml
@@ -1,5 +1,0 @@
-<menu id="SetsMenu" title="Sets">
-    <menu-item id="sets_unlimited" label="Unlimited" />
-    <menu-item id="sets_3" label="3" />
-    <menu-item id="sets_5" label="5" />
-</menu>

--- a/resources/menus/super_tie.xml
+++ b/resources/menus/super_tie.xml
@@ -1,4 +1,0 @@
-<menu id="SuperTieMenu" title="Super Tie">
-    <menu-item id="super_tie_yes" label="Yes" />
-    <menu-item id="super_tie_no" label="No" />
-</menu>

--- a/source/delegates/initialScreenDelegate.mc
+++ b/source/delegates/initialScreenDelegate.mc
@@ -8,13 +8,30 @@ class InitialScreenDelegate extends WatchUi.InputDelegate {
     }
 
     function onKey(keyEvent as WatchUi.KeyEvent) as Boolean {
-
         switch (keyEvent.getKey()) {
             case KEY_ESC: {
                 System.exit();
             }
             case KEY_ENTER: {
-                WatchUi.pushView(new Rez.Menus.GoldenPointMenu(), new MenuGoldenPointDelegate(), WatchUi.SLIDE_BLINK);
+
+                var menu = new WatchUi.Menu2({:title=>"Score"});
+                menu.addItem(
+                    new MenuItem(
+                        "Golden Point",
+                        "",
+                        :golden_point_yes,
+                        {}
+                    )
+                );
+                menu.addItem(
+                    new MenuItem(
+                        "Advantages",
+                        "",
+                        :golden_point_no,
+                        {}
+                    )
+                );
+                WatchUi.pushView(menu, new MenuGoldenPointDelegate(), WatchUi.SLIDE_BLINK);
                 break;
             }
         }

--- a/source/delegates/menu/menuGoldenPointDelegate.mc
+++ b/source/delegates/menu/menuGoldenPointDelegate.mc
@@ -2,23 +2,49 @@ import Toybox.Lang;
 import Toybox.System;
 import Toybox.WatchUi;
 
-class MenuGoldenPointDelegate extends WatchUi.MenuInputDelegate {
+class MenuGoldenPointDelegate extends WatchUi.Menu2InputDelegate {
 
     function initialize() {
-        MenuInputDelegate.initialize();
+        Menu2InputDelegate.initialize();
     }
 
-    function onMenuItem(item as Symbol) as Void {
-        
-        var goldenPoint = true;
-        if (item == :golden_point_yes) {
+    function onSelect(item as MenuItem) {
+       var goldenPoint = true;
+        if (item.getId() == :golden_point_yes) {
             goldenPoint = true;
-        } else if (item == :golden_point_no) {
+        } else if (item.getId() == :golden_point_no) {
             goldenPoint = false;
         }
 
         Application.getApp().getMatchConfig().setGoldenPoint(goldenPoint);
-        WatchUi.pushView(new Rez.Menus.SetsMenu(), new MenuNumberSetsDelegate(), WatchUi.SLIDE_BLINK);
+
+         var menu = new WatchUi.Menu2({:title=>"Sets"});
+                menu.addItem(
+                    new MenuItem(
+                        "Unlimited",
+                        "",
+                        :sets_unlimited,
+                        {}
+                    )
+                );
+                 menu.addItem(
+                    new MenuItem(
+                        "3",
+                        "",
+                        :sets_3,
+                        {}
+                    )
+                );
+                 menu.addItem(
+                    new MenuItem(
+                        "5",
+                        "",
+                        :sets_5,
+                        {}
+                    )
+                );
+                
+        WatchUi.pushView(menu, new MenuNumberSetsDelegate(), WatchUi.SLIDE_BLINK);
     }
 
 }

--- a/source/delegates/menu/menuNumberSetsDelegate.mc
+++ b/source/delegates/menu/menuNumberSetsDelegate.mc
@@ -2,17 +2,17 @@ import Toybox.Lang;
 import Toybox.System;
 import Toybox.WatchUi;
 
-class MenuNumberSetsDelegate extends WatchUi.MenuInputDelegate {
+class MenuNumberSetsDelegate extends WatchUi.Menu2InputDelegate {
 
     function initialize() {
-        MenuInputDelegate.initialize();
+        Menu2InputDelegate.initialize();
     }
 
-    function onMenuItem(item as Symbol) as Void {
+    function onSelect(item as MenuItem) as Void {
         
         var nbrSets = MatchConfig.UNLIMITED_SETS;
 
-         switch (item) {
+         switch (item.getId()) {
             case :sets_unlimited: {
                 break;
             }
@@ -30,7 +30,33 @@ class MenuNumberSetsDelegate extends WatchUi.MenuInputDelegate {
 
         // if not unlimited sets, lets ask about super tie config
         if (nbrSets != MatchConfig.UNLIMITED_SETS) {
-            WatchUi.pushView(new Rez.Menus.SuperTieMenu(), new MenuSuperTieDelegate(), WatchUi.SLIDE_BLINK);
+            var menu = new WatchUi.Menu2({:title=>"Super Tie"});
+                menu.addItem(
+                    new MenuItem(
+                        "Yes",
+                        "",
+                        :super_tie_yes,
+                        {}
+                    )
+                );
+                 menu.addItem(
+                    new MenuItem(
+                        "No",
+                        "",
+                        :super_tie_no,
+                        {}
+                    )
+                );
+                 menu.addItem(
+                    new MenuItem(
+                        "5",
+                        "",
+                        :sets_5,
+                        {}
+                    )
+                );
+                
+        WatchUi.pushView(menu, new MenuSuperTieDelegate(), WatchUi.SLIDE_BLINK);
         } else {
             Application.getApp().initMatch();
             WatchUi.pushView(new ScoreView(), new ScoreDelegate(), WatchUi.SLIDE_UP);

--- a/source/delegates/menu/menuSuperTieDelegate.mc
+++ b/source/delegates/menu/menuSuperTieDelegate.mc
@@ -2,18 +2,17 @@ import Toybox.Lang;
 import Toybox.System;
 import Toybox.WatchUi;
 
-class MenuSuperTieDelegate extends WatchUi.MenuInputDelegate {
+class MenuSuperTieDelegate extends WatchUi.Menu2InputDelegate {
 
     function initialize() {
-        MenuInputDelegate.initialize();
+        Menu2InputDelegate.initialize();
     }
 
-    function onMenuItem(item as Symbol) as Void {
-        
+    function onSelect(item as MenuItem) as Void {
         var superTie = false;
-        if (item == :super_tie_yes) {
+        if (item.getId() == :super_tie_yes) {
             superTie = true;
-        } else if (item == :super_tie_no) {
+        } else if (item.getId() == :super_tie_no) {
             superTie = false;
         }
 


### PR DESCRIPTION
fixes #120  (or tries 😄 )

according with forum replies, menu is legacy, and may contain a bug, which wont be solved because it's legacy. let's try the newer menu2 thing

see docs https://developer.garmin.com/connect-iq/api-docs/Toybox/WatchUi/Menu2.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Menus for "Golden Point", "Sets", and "Super Tie" are now generated dynamically within the app, allowing for a more flexible and responsive user interface.

* **Refactor**
  * Updated menu handling to use the latest menu framework, improving menu interaction and consistency.
  * Menu selection logic has been modernized for better reliability and user experience.

* **Chores**
  * Removed obsolete static menu resource files, streamlining the app's resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->