### PR TITLE
support fenix8 pro microled

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -47,6 +47,7 @@
             <iq:product id="fenix7xpronowifi"/>
             <iq:product id="fenix843mm"/>
             <iq:product id="fenix847mm"/>
+            <iq:product id="fenix8pro47mm"/>
             <iq:product id="fenix8solar47mm"/>
             <iq:product id="fenix8solar51mm"/>
             <iq:product id="fenixe"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Fenix 8 Pro (47mm). Users with this device can now install, run, and receive updates for the app.
  * The device will appear as compatible in the Connect IQ Store and within in-app compatibility listings.
  * No functional changes for existing devices; existing users remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->