### PR TITLE
allow to discard on finish

### DIFF
--- a/source/delegates/endOfMatchDelegate.mc
+++ b/source/delegates/endOfMatchDelegate.mc
@@ -11,26 +11,30 @@ class EndOfMatchDelegate extends WatchUi.InputDelegate {
         switch (keyEvent.getKey()) {
             case KEY_ESC: {}
             case KEY_ENTER: {
-                showFinishDialog();
+                showFinishMenu();
             }
         }
         return true;
     }
 
     function onTap(clickEvent as WatchUi.ClickEvent) as Boolean {
-        showFinishDialog();
+        showFinishMenu();
         return true;
     }
 
-    private function showFinishDialog() as Void {
+    private function showFinishMenu() as Void {
         var score = Application.getApp().getScoreString();
-        var message = "Finish Activity?\n" + score;
-        var dialog = new WatchUi.Confirmation(message);
-        WatchUi.pushView(
-            dialog,
-            new ExitConfirmationDelegate(),
-            WatchUi.SLIDE_IMMEDIATE
+        var menu = new WatchUi.Menu2({:title=>"Finish Activity"});
+        menu.addItem(
+            new MenuItem("Save and exit", score, :finish_save_exit, {})
         );
+        menu.addItem(
+            new MenuItem("Discard", "Don't save activity", :finish_discard, {})
+        );
+        menu.addItem(
+            new MenuItem("Cancel", "Back to summary", :finish_cancel, {})
+        );
+        WatchUi.pushView(menu, new FinishActivityMenuDelegate(), WatchUi.SLIDE_IMMEDIATE);
     }
 
 }

--- a/source/delegates/finishActivityMenuDelegate.mc
+++ b/source/delegates/finishActivityMenuDelegate.mc
@@ -1,0 +1,26 @@
+import Toybox.Lang;
+import Toybox.WatchUi;
+using Toybox.System;
+
+class FinishActivityMenuDelegate extends WatchUi.Menu2InputDelegate {
+
+    function initialize() {
+        Menu2InputDelegate.initialize();
+    }
+
+    function onSelect(item as MenuItem) as Void {
+        if (item.getId() == :finish_save_exit) {
+            WatchUi.popView(WatchUi.SLIDE_IMMEDIATE);
+            Application.getApp().saveSession();
+            System.exit();
+        } else if (item.getId() == :finish_discard) {
+            WatchUi.popView(WatchUi.SLIDE_IMMEDIATE);
+            Application.getApp().discardSession();
+            System.exit();
+        } else if (item.getId() == :finish_cancel) {
+            // just close the menu and go back
+            WatchUi.popView(WatchUi.SLIDE_IMMEDIATE);
+        }
+    }
+}
+

--- a/source/delegates/scoreDelegate.mc
+++ b/source/delegates/scoreDelegate.mc
@@ -93,13 +93,18 @@ class ScoreDelegate extends WatchUi.InputDelegate {
             }
             case KEY_ESC: {
                 var score = Application.getApp().getScoreString();
-                var message = "Finish Activity?\n" + score;
-                var dialog = new WatchUi.Confirmation(message);
-                WatchUi.pushView(
-                    dialog,
-                    new ExitConfirmationDelegate(),
-                    WatchUi.SLIDE_IMMEDIATE
+                var menu = new WatchUi.Menu2({:title=>"Finish Activity"});
+                menu.addItem(
+                    new MenuItem("Save and exit", score, :finish_save_exit, {})
                 );
+                menu.addItem(
+                    new MenuItem("Discard", "Don't save activity", :finish_discard, {})
+                );
+                menu.addItem(
+                    new MenuItem("Cancel", "Back to score", :finish_cancel, {})
+                );
+                WatchUi.pushView(menu, new FinishActivityMenuDelegate(), WatchUi.SLIDE_IMMEDIATE);
+                break;
             }
             case KEY_MENU: {
                 break;

--- a/source/delegates/scoreOptionsMenuDelegate.mc
+++ b/source/delegates/scoreOptionsMenuDelegate.mc
@@ -24,13 +24,17 @@ class ScoreOptionsMenuDelegate extends WatchUi.Menu2InputDelegate {
         } else if (item.getId() == :score_option_finish) {
             WatchUi.popView(WatchUi.SLIDE_IMMEDIATE);
             var score = Application.getApp().getScoreString();
-            var message = "Finish Activity?\n" + score;
-            var dialog = new WatchUi.Confirmation(message);
-            WatchUi.pushView(
-                dialog,
-                new ExitConfirmationDelegate(),
-                WatchUi.SLIDE_IMMEDIATE
+            var menu = new WatchUi.Menu2({:title=>"Finish Activity"});
+            menu.addItem(
+                new MenuItem("Save and exit", score, :finish_save_exit, {})
             );
+            menu.addItem(
+                new MenuItem("Discard", "Don't save activity", :finish_discard, {})
+            );
+            menu.addItem(
+                new MenuItem("Cancel", "Back to score", :finish_cancel, {})
+            );
+            WatchUi.pushView(menu, new FinishActivityMenuDelegate(), WatchUi.SLIDE_IMMEDIATE);
         }
     }
 

--- a/source/garminpadelApp.mc
+++ b/source/garminpadelApp.mc
@@ -97,6 +97,18 @@ class GarminpadelApp extends Application.AppBase {
         session.save();
     }
 
+    function discardSession() as Void {
+        var session = getSession();
+
+        if (session == null) {
+            return;
+        }
+
+        // stop recording but do not save a FIT file
+        session.stop();
+        session.discard();
+    }
+
     function computeTotalSteps() as Number {
         var currentDay = Gregorian.info(Time.now(), Time.FORMAT_SHORT).day;
         


### PR DESCRIPTION
this allows users to discard activity when finishing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Redesigned activity completion interface with a new "Finish Activity" menu throughout the app.
  * Users can now choose between three actions when finishing: "Save and exit" to record the activity and score, "Discard" to exit without saving, or "Cancel" to return to the activity summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->