### PR TITLE
keep match status params to 9 max

### DIFF
--- a/source/model/matchStatus.mc
+++ b/source/model/matchStatus.mc
@@ -23,38 +23,36 @@ class MatchStatus {
 
 
     static function New() as MatchStatus {
-        return new MatchStatus(0,0,0,0,0,0,0,0, [], 0);
+        return new MatchStatus(0, 0, 0, 0, 0, 0, 0, 0, []);
     }
 
+    // Max 9 arguments for compatibility with older devices (e.g. marqgolfer)
     function initialize(
-        p1Sets  as Number, 
-        p2Sets as Number, 
-        p1Games as Number, 
-        p2Games as Number, 
-        p1ScoreIdx as Number, 
-        p2ScoreIdx as Number, 
-        p1TieBreakScore as Number, 
-        p2TieBreakScore as Number, 
-        historicalScores as Array<String>,
-        unforcedErrors as Number
+        p1Sets  as Number,
+        p2Sets as Number,
+        p1Games as Number,
+        p2Games as Number,
+        p1ScoreIdx as Number,
+        p2ScoreIdx as Number,
+        p1TieBreakScore as Number,
+        p2TieBreakScore as Number,
+        historicalScores as Array<String>
     ) {
-
         self.p1Sets = p1Sets;
         self.p2Sets = p2Sets;
-
         self.p1Games = p1Games;
         self.p2Games = p2Games;
-        
         self.p1ScoreIdx = p1ScoreIdx;
         self.p2ScoreIdx = p2ScoreIdx;
-
         self.p1TieBreakScore = p1TieBreakScore;
         self.p2TieBreakScore = p2TieBreakScore;
-
         self.historicalScores = historicalScores;
+        self.unforcedErrors = 0;
+    }
 
-        self.unforcedErrors = unforcedErrors;
-     }
+    function setUnforcedErrors(n as Number) as Void {
+        self.unforcedErrors = n;
+    }
 
 
     function getP1Sets() as Number {
@@ -160,6 +158,8 @@ class MatchStatus {
     function copy() as MatchStatus {
         var newHistory = [];
         newHistory.addAll(self.historicalScores);
-        return new MatchStatus(p1Sets, p2Sets, p1Games, p2Games, p1ScoreIdx, p2ScoreIdx, p1TieBreakScore, p2TieBreakScore, newHistory, unforcedErrors);
+        var s = new MatchStatus(p1Sets, p2Sets, p1Games, p2Games, p1ScoreIdx, p2ScoreIdx, p1TieBreakScore, p2TieBreakScore, newHistory);
+        s.setUnforcedErrors(self.unforcedErrors);
+        return s;
     }
 }


### PR DESCRIPTION
```
ERROR: marqgolfer: /Users/pedrorijo/repo/garmin-padel/source/model/matchStatus.mc:29: Too many arguments passed to method 'initialize'. Only 9 arguments are allowed.
```

cursor says
 
```
Monkey C on some older devices (e.g. marqgolfer, MARQ 2019) limits method arguments to 9. MatchStatus.initialize has 10 parameters, so it fails only on those devices
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling and initialization patterns for error tracking in match data management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->