### PR TITLE
add support for silver and star point

### DIFF
--- a/source/delegates/initialScreenDelegate.mc
+++ b/source/delegates/initialScreenDelegate.mc
@@ -32,7 +32,15 @@ class InitialScreenDelegate extends WatchUi.InputDelegate {
             new MenuItem(
                 "Golden Point",
                 "",
-                :golden_point_yes,
+                :point_rule_golden,
+                {}
+            )
+        );
+        menu.addItem(
+            new MenuItem(
+                "Star Point",
+                "",
+                :point_rule_star,
                 {}
             )
         );
@@ -40,7 +48,15 @@ class InitialScreenDelegate extends WatchUi.InputDelegate {
             new MenuItem(
                 "Advantages",
                 "",
-                :golden_point_no,
+                :point_rule_advantage,
+                {}
+            )
+        );
+        menu.addItem(
+            new MenuItem(
+                "Silver Point",
+                "",
+                :point_rule_silver,
                 {}
             )
         );

--- a/source/delegates/menu/menuGoldenPointDelegate.mc
+++ b/source/delegates/menu/menuGoldenPointDelegate.mc
@@ -9,14 +9,18 @@ class MenuGoldenPointDelegate extends WatchUi.Menu2InputDelegate {
     }
 
     function onSelect(item as MenuItem) {
-       var goldenPoint = true;
-        if (item.getId() == :golden_point_yes) {
-            goldenPoint = true;
-        } else if (item.getId() == :golden_point_no) {
-            goldenPoint = false;
+        var rule = MatchConfig.POINT_RULE_GOLDEN;
+        var id = item.getId();
+        if (id == :point_rule_golden) {
+            rule = MatchConfig.POINT_RULE_GOLDEN;
+        } else if (id == :point_rule_advantage) {
+            rule = MatchConfig.POINT_RULE_ADVANTAGE;
+        } else if (id == :point_rule_silver) {
+            rule = MatchConfig.POINT_RULE_SILVER;
+        } else if (id == :point_rule_star) {
+            rule = MatchConfig.POINT_RULE_STAR;
         }
-
-        Application.getApp().getMatchConfig().setGoldenPoint(goldenPoint);
+        Application.getApp().getMatchConfig().setPointRule(rule);
 
          var menu = new WatchUi.Menu2({:title=>"Sets"});
                 menu.addItem(

--- a/source/model/GameEngine.mc
+++ b/source/model/GameEngine.mc
@@ -72,3 +72,50 @@ class AdvantageGameEngine extends GameEngine {
         return false;
     }
 }
+
+// Advantage with a decisive point after N reverts to deuce (Silver = 1, Star = 2).
+// Shared logic for Silver and Star point.
+class LimitedAdvantageGameEngine extends GameEngine {
+
+    private var revertThreshold as Number;
+
+    function initialize(threshold as Number) {
+        GameEngine.initialize();
+        self.revertThreshold = threshold;
+    }
+
+    function scorePoint(side as Number, matchStatus as MatchStatus) as Boolean {
+        var opponent = self.otherSide(side);
+        var sideScore = self.getScoreForSide(side, matchStatus);
+        var oppScore = self.getScoreForSide(opponent, matchStatus);
+
+        if (sideScore == 40 && oppScore == 40 && matchStatus.getDeuceRevertCount() >= self.revertThreshold) {
+            return true; // decisive point
+        }
+        if (oppScore == 'A') {
+            matchStatus.setDeuce();
+            return false;
+        }
+        if (sideScore == 'A' || (sideScore == 40 && oppScore != 40)) {
+            return true;
+        }
+        self.incScoreForSide(side, matchStatus);
+        return false;
+    }
+}
+
+// Silver point: one advantage; if we revert to deuce, the next point is golden.
+class SilverPointGameEngine extends LimitedAdvantageGameEngine {
+
+    function initialize() {
+        LimitedAdvantageGameEngine.initialize(1);
+    }
+}
+
+// FIP Star point: up to two advantage cycles; after second revert, next point is Star Point.
+class StarPointGameEngine extends LimitedAdvantageGameEngine {
+
+    function initialize() {
+        LimitedAdvantageGameEngine.initialize(2);
+    }
+}

--- a/source/model/PadelMatch.mc
+++ b/source/model/PadelMatch.mc
@@ -7,12 +7,7 @@ class PadelMatch {
     private var matchEngine as MatchEngine;
 
     function initialize(config as MatchConfig) {
-        var gameEngine;
-        if (config.getGoldenPoint()) {
-            gameEngine = new GoldenPointGameEngine();
-        } else {
-            gameEngine = new AdvantageGameEngine();
-        }
+        var gameEngine = self.gameEngineForPointRule(config.getPointRule());
         var defaultSetEngine = new NormalSetEngine(gameEngine);
         var decidingSetEngine = null;
         if (config.getSuperTie()) {
@@ -55,5 +50,21 @@ class PadelMatch {
 
     function isInSuperTieBreak() as Boolean {
         return self.matchEngine.isInSuperTieBreak();
+    }
+
+    private function gameEngineForPointRule(rule as Number) as GameEngine {
+        if (rule == MatchConfig.POINT_RULE_GOLDEN) {
+            return new GoldenPointGameEngine();
+        }
+        if (rule == MatchConfig.POINT_RULE_ADVANTAGE) {
+            return new AdvantageGameEngine();
+        }
+        if (rule == MatchConfig.POINT_RULE_SILVER) {
+            return new SilverPointGameEngine();
+        }
+        if (rule == MatchConfig.POINT_RULE_STAR) {
+            return new StarPointGameEngine();
+        }
+        return new GoldenPointGameEngine();
     }
 }

--- a/source/model/matchConfig.mc
+++ b/source/model/matchConfig.mc
@@ -4,22 +4,35 @@ class MatchConfig {
 
     public static const UNLIMITED_SETS = 20;
 
+    public static const POINT_RULE_GOLDEN = 0;
+    public static const POINT_RULE_ADVANTAGE = 1;
+    public static const POINT_RULE_SILVER = 2;
+    public static const POINT_RULE_STAR = 3;
+
     private var superTie as Boolean;
     private var numberOfSets as Number;
-    private var goldenPoint as Boolean;
+    private var pointRule as Number;
 
     function initialize() {
-        superTie = false; 
-        numberOfSets =  UNLIMITED_SETS;   
-        goldenPoint = true; 
+        superTie = false;
+        numberOfSets = UNLIMITED_SETS;
+        pointRule = POINT_RULE_GOLDEN;
+    }
+
+    function setPointRule(rule as Number) as Void {
+        self.pointRule = rule;
+    }
+
+    function getPointRule() as Number {
+        return self.pointRule;
     }
 
     function setGoldenPoint(goldenPoint as Boolean) as Void {
-        self.goldenPoint = goldenPoint;
+        self.pointRule = goldenPoint ? POINT_RULE_GOLDEN : POINT_RULE_ADVANTAGE;
     }
 
     function getGoldenPoint() as Boolean {
-        return self.goldenPoint;
+        return self.pointRule == POINT_RULE_GOLDEN;
     }
 
     function setSuperTie(enabled as Boolean) as Void {
@@ -38,8 +51,8 @@ class MatchConfig {
         return self.numberOfSets;
     }
 
-    function toString() as Lang.String  {
-        return "matchConfig: " + "superTie: " + self.superTie + ", sets: " + self.numberOfSets + ", golden: " + self.goldenPoint;
+    function toString() as Lang.String {
+        return "matchConfig: " + "superTie: " + self.superTie + ", sets: " + self.numberOfSets + ", pointRule: " + self.pointRule;
     }
 
 }

--- a/source/model/matchStatus.mc
+++ b/source/model/matchStatus.mc
@@ -21,6 +21,8 @@ class MatchStatus {
     // total unforced errors for our team during the whole match
     private var unforcedErrors as Number;
 
+    // number of times we have returned to 40-40 after having advantage (for Silver/Star point)
+    private var deuceRevertCount as Number;
 
     static function New() as MatchStatus {
         return new MatchStatus(0, 0, 0, 0, 0, 0, 0, 0, []);
@@ -48,6 +50,15 @@ class MatchStatus {
         self.p2TieBreakScore = p2TieBreakScore;
         self.historicalScores = historicalScores;
         self.unforcedErrors = 0;
+        self.deuceRevertCount = 0;
+    }
+
+    function getDeuceRevertCount() as Number {
+        return self.deuceRevertCount;
+    }
+
+    function setDeuceRevertCount(n as Number) as Void {
+        self.deuceRevertCount = n;
     }
 
     function setUnforcedErrors(n as Number) as Void {
@@ -132,6 +143,7 @@ class MatchStatus {
     function setDeuce() as Void {
         self.p1ScoreIdx = 3;
         self.p2ScoreIdx = 3;
+        self.deuceRevertCount++;
     }
 
     function resetGames() as Void {
@@ -145,6 +157,7 @@ class MatchStatus {
 
         self.p2ScoreIdx = 0;
         self.p2TieBreakScore = 0;
+        self.deuceRevertCount = 0;
     }
 
     function getUnforcedErrors() as Number {
@@ -160,6 +173,7 @@ class MatchStatus {
         newHistory.addAll(self.historicalScores);
         var s = new MatchStatus(p1Sets, p2Sets, p1Games, p2Games, p1ScoreIdx, p2ScoreIdx, p1TieBreakScore, p2TieBreakScore, newHistory);
         s.setUnforcedErrors(self.unforcedErrors);
+        s.setDeuceRevertCount(self.deuceRevertCount);
         return s;
     }
 }

--- a/source/tests/testGameEngine.mc
+++ b/source/tests/testGameEngine.mc
@@ -75,3 +75,85 @@ function advantage_p2Advantage_p2WinsGame(logger as Logger) as Boolean {
     var won = engine.scorePoint(Sides.SIDE_P2, status);
     return won == true;
 }
+
+// --- Silver point (one advantage then golden at second deuce) ---
+
+(:test)
+function silverPoint_atFirstDeuce_p1GetsAdvantage(logger as Logger) as Boolean {
+    var engine = new SilverPointGameEngine();
+    var status = statusDeuce();
+    var won = engine.scorePoint(Sides.SIDE_P1, status);
+    return won == false && status.getP1Score() == 'A' && status.getP2Score() == 40;
+}
+
+(:test)
+function silverPoint_afterOneRevert_nextPointWinsGame(logger as Logger) as Boolean {
+    var engine = new SilverPointGameEngine();
+    var status = statusDeuceWithRevertCount(1);
+    var wonP1 = engine.scorePoint(Sides.SIDE_P1, status);
+    return wonP1 == true;
+}
+
+(:test)
+function silverPoint_afterOneRevert_p2WinsGolden(logger as Logger) as Boolean {
+    var engine = new SilverPointGameEngine();
+    var status = statusDeuceWithRevertCount(1);
+    var won = engine.scorePoint(Sides.SIDE_P2, status);
+    return won == true;
+}
+
+(:test)
+function silverPoint_firstDeuce_thenRevert_thenP1WinsGolden(logger as Logger) as Boolean {
+    var engine = new SilverPointGameEngine();
+    var status = statusDeuce();
+    engine.scorePoint(Sides.SIDE_P1, status);
+    engine.scorePoint(Sides.SIDE_P2, status);
+    var won = engine.scorePoint(Sides.SIDE_P1, status);
+    return won == true;
+}
+
+// --- Star point (FIP: two advantage cycles then golden point) ---
+
+(:test)
+function starPoint_atFirstDeuce_advantageNormal(logger as Logger) as Boolean {
+    var engine = new StarPointGameEngine();
+    var status = statusDeuce();
+    var won = engine.scorePoint(Sides.SIDE_P1, status);
+    return won == false && status.getP1Score() == 'A' && status.getP2Score() == 40;
+}
+
+(:test)
+function starPoint_afterOneRevert_stillAdvantageNotStar(logger as Logger) as Boolean {
+    var engine = new StarPointGameEngine();
+    var status = statusDeuceWithRevertCount(1);
+    var won = engine.scorePoint(Sides.SIDE_P1, status);
+    return won == false && status.getP1Score() == 'A' && status.getP2Score() == 40;
+}
+
+(:test)
+function starPoint_afterTwoReverts_nextPointWinsStarPoint(logger as Logger) as Boolean {
+    var engine = new StarPointGameEngine();
+    var status = statusDeuceWithRevertCount(2);
+    var wonP1 = engine.scorePoint(Sides.SIDE_P1, status);
+    return wonP1 == true;
+}
+
+(:test)
+function starPoint_afterTwoReverts_p2WinsStarPoint(logger as Logger) as Boolean {
+    var engine = new StarPointGameEngine();
+    var status = statusDeuceWithRevertCount(2);
+    var won = engine.scorePoint(Sides.SIDE_P2, status);
+    return won == true;
+}
+
+(:test)
+function starPoint_fullSequence_twoRevertsThenP1Wins(logger as Logger) as Boolean {
+    var engine = new StarPointGameEngine();
+    var status = statusDeuce();
+    engine.scorePoint(Sides.SIDE_P1, status);
+    engine.scorePoint(Sides.SIDE_P2, status);
+    engine.scorePoint(Sides.SIDE_P2, status);
+    engine.scorePoint(Sides.SIDE_P1, status);
+    var won = engine.scorePoint(Sides.SIDE_P1, status);
+    return won == true;
+}

--- a/source/tests/testingUtils.mc
+++ b/source/tests/testingUtils.mc
@@ -90,6 +90,14 @@ function statusP2Advantage() as MatchStatus {
     return new MatchStatus(0, 0, 0, 0, 3, 4, 0, 0, hist);
 }
 
+// MatchStatus at 40-40 with given deuce revert count (for Silver: 1 = golden next; Star: 2 = star point next).
+function statusDeuceWithRevertCount(count as Number) as MatchStatus {
+    var hist = [];
+    var status = new MatchStatus(0, 0, 0, 0, 3, 3, 0, 0, hist);
+    status.setDeuceRevertCount(count);
+    return status;
+}
+
 // Play one full game (4 points) for the given side with NormalSetEngine (golden point).
 function playOneGame(engine as NormalSetEngine, side as Number, status as MatchStatus) as Void {
     for (var i = 0; i < 4; i++) {


### PR DESCRIPTION
closes #69 
closes #142 

<img width="704" height="846" alt="image" src="https://github.com/user-attachments/assets/aee7ae2e-b687-47c3-86db-84a5c8aef758" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Silver Point and Star Point scoring variants and expanded the match configuration to offer four point-rule options (Golden, Advantage, Silver, Star).
  * Point-rule selection now drives scoring behavior for each match.

* **Behavior**
  * Scoring now tracks deuce reversion counts to support Silver/Star rule mechanics (affects when decisive points occur).

* **Tests**
  * Added comprehensive tests covering Silver Point and Star Point scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->