### PR TITLE
introduce game modes

### DIFF
--- a/source/delegates/initialScreenDelegate.mc
+++ b/source/delegates/initialScreenDelegate.mc
@@ -27,12 +27,13 @@ class InitialScreenDelegate extends WatchUi.InputDelegate {
     }
 
     private function openConfigMenu() as Void {
-        var menu = new WatchUi.Menu2({:title=>"Sets"});
-        menu.addItem(new MenuItem("1", "", :sets_1, {}));
-        menu.addItem(new MenuItem("3", "", :sets_3, {}));
-        menu.addItem(new MenuItem("5", "", :sets_5, {}));
-        menu.addItem(new MenuItem("Unlimited", "", :sets_unlimited, {}));
-        WatchUi.pushView(menu, new MenuNumberSetsDelegate(), WatchUi.SLIDE_BLINK);
+        var menu = new WatchUi.Menu2({:title=>"Game Mode"});
+        menu.addItem(new MenuItem("Tournament", "", GameModes.MODE_TOURNAMENT, {}));
+        menu.addItem(new MenuItem("Tournament (super)", "", GameModes.MODE_TOURNAMENT_SUPER, {}));
+        menu.addItem(new MenuItem("Pro Set Tournament", "", GameModes.MODE_PRO_SET_TOURNAMENT, {}));
+        menu.addItem(new MenuItem("Friendly", "", GameModes.MODE_FRIENDLY, {}));
+        menu.addItem(new MenuItem("Custom", "", GameModes.MODE_CUSTOM, {}));
+        WatchUi.pushView(menu, new MenuGameModeDelegate(), WatchUi.SLIDE_BLINK);
     }
 
 }

--- a/source/delegates/menu/menuGameModeConfirmDelegate.mc
+++ b/source/delegates/menu/menuGameModeConfirmDelegate.mc
@@ -1,0 +1,21 @@
+import Toybox.Lang;
+import Toybox.WatchUi;
+
+// Confirmation screen after selecting a preset game mode.
+// Shows the configuration summary; START/ENTER begins the match, BACK returns to the mode menu.
+class MenuGameModeConfirmDelegate extends WatchUi.Menu2InputDelegate {
+
+    function initialize() {
+        Menu2InputDelegate.initialize();
+    }
+
+    function onSelect(item as MenuItem) as Void {
+        if (item.getId() != :mode_start_confirm) {
+            return;
+        }
+        // MatchConfig was already populated in MenuGameModeDelegate.
+        Application.getApp().initMatch();
+        WatchUi.pushView(new ScoreView(), new ScoreDelegate(), WatchUi.SLIDE_UP);
+    }
+}
+

--- a/source/delegates/menu/menuGameModeDelegate.mc
+++ b/source/delegates/menu/menuGameModeDelegate.mc
@@ -1,0 +1,60 @@
+import Toybox.Lang;
+import Toybox.WatchUi;
+
+class MenuGameModeDelegate extends WatchUi.Menu2InputDelegate {
+
+    function initialize() {
+        Menu2InputDelegate.initialize();
+    }
+
+    function onSelect(item as MenuItem) as Void {
+        var idObj = item.getId();
+        if (idObj == null) {
+            return;
+        }
+        var id = idObj as Symbol;
+
+        if (id == GameModes.MODE_CUSTOM) {
+            // Go into the existing custom configuration flow: Sets -> Set Type -> (Super Tie) -> Score.
+            pushSetsMenu();
+            return;
+        }
+
+        var presetConfig = GameModes.configForMode(id);
+        if (presetConfig != null) {
+            var appConfig = Application.getApp().getMatchConfig();
+            appConfig.setNumberOfSets(presetConfig.getNumberOfSets());
+            appConfig.setSetType(presetConfig.getSetType());
+            appConfig.setSuperTie(presetConfig.getSuperTie());
+            appConfig.setPointRule(presetConfig.getPointRule());
+            var lines = GameModes.summaryLines(id);
+            self.pushModeConfirmMenu(
+                GameModes.title(id),
+                lines[0],
+                lines[1],
+                lines[2],
+                lines[3]
+            );
+        }
+    }
+
+    private function pushSetsMenu() as Void {
+        var menu = new WatchUi.Menu2({:title=>"Sets"});
+        menu.addItem(new MenuItem("1", "", :sets_1, {}));
+        menu.addItem(new MenuItem("3", "", :sets_3, {}));
+        menu.addItem(new MenuItem("5", "", :sets_5, {}));
+        menu.addItem(new MenuItem("Unlimited", "", :sets_unlimited, {}));
+        WatchUi.pushView(menu, new MenuNumberSetsDelegate(), WatchUi.SLIDE_BLINK);
+    }
+
+    private function pushModeConfirmMenu(title as String, line1 as String, line2 as String, line3 as String, line4 as String) as Void {
+        var menu = new WatchUi.Menu2({:title=>title});
+        menu.addItem(new MenuItem(line1, "", :mode_info_1, {}));
+        menu.addItem(new MenuItem(line2, "", :mode_info_2, {}));
+        menu.addItem(new MenuItem(line3, "", :mode_info_3, {}));
+        menu.addItem(new MenuItem(line4, "", :mode_info_4, {}));
+        menu.addItem(new MenuItem("Start match", "Press ENTER/START", :mode_start_confirm, {}));
+        WatchUi.pushView(menu, new MenuGameModeConfirmDelegate(), WatchUi.SLIDE_BLINK);
+    }
+}
+

--- a/source/model/GameModes.mc
+++ b/source/model/GameModes.mc
@@ -1,0 +1,81 @@
+import Toybox.Lang;
+
+// Preset game modes and mapping to MatchConfig.
+class GameModes {
+
+    static const MODE_TOURNAMENT = :mode_tournament;
+    static const MODE_TOURNAMENT_SUPER = :mode_tournament_super;
+    static const MODE_PRO_SET_TOURNAMENT = :mode_pro_set_tournament;
+    static const MODE_FRIENDLY = :mode_friendly;
+    static const MODE_CUSTOM = :mode_custom;
+
+    // Returns a new MatchConfig for the given preset, or null for Custom.
+    static function configForMode(modeId as Symbol) as MatchConfig or Null {
+        if (modeId == MODE_TOURNAMENT) {
+            var c = new MatchConfig();
+            c.setNumberOfSets(3);
+            c.setSetType(MatchConfig.SET_TYPE_NORMAL);
+            c.setSuperTie(false);
+            c.setPointRule(MatchConfig.POINT_RULE_GOLDEN);
+            return c;
+        }
+        if (modeId == MODE_TOURNAMENT_SUPER) {
+            var c = new MatchConfig();
+            c.setNumberOfSets(3);
+            c.setSetType(MatchConfig.SET_TYPE_NORMAL);
+            c.setSuperTie(true);
+            c.setPointRule(MatchConfig.POINT_RULE_GOLDEN);
+            return c;
+        }
+        if (modeId == MODE_PRO_SET_TOURNAMENT) {
+            var c = new MatchConfig();
+            c.setNumberOfSets(1);
+            c.setSetType(MatchConfig.SET_TYPE_PRO);
+            c.setSuperTie(false);
+            c.setPointRule(MatchConfig.POINT_RULE_GOLDEN);
+            return c;
+        }
+        if (modeId == MODE_FRIENDLY) {
+            var c = new MatchConfig();
+            c.setNumberOfSets(MatchConfig.UNLIMITED_SETS);
+            c.setSetType(MatchConfig.SET_TYPE_NORMAL);
+            c.setSuperTie(false);
+            c.setPointRule(MatchConfig.POINT_RULE_GOLDEN);
+            return c;
+        }
+        return null;
+    }
+
+    static function title(modeId as Symbol) as String {
+        if (modeId == MODE_TOURNAMENT) {
+            return "Tournament";
+        }
+        if (modeId == MODE_TOURNAMENT_SUPER) {
+            return "Tournament (super)";
+        }
+        if (modeId == MODE_PRO_SET_TOURNAMENT) {
+            return "Pro Set Tournament";
+        }
+        if (modeId == MODE_FRIENDLY) {
+            return "Friendly";
+        }
+        return "Game Mode";
+    }
+
+    static function summaryLines(modeId as Symbol) as Array<String> {
+        if (modeId == MODE_TOURNAMENT) {
+            return ["Sets: 3", "Set type: Normal", "Super tie: No", "Score: Golden Point"];
+        }
+        if (modeId == MODE_TOURNAMENT_SUPER) {
+            return ["Sets: 3", "Set type: Normal", "Super tie: Yes", "Score: Golden Point"];
+        }
+        if (modeId == MODE_PRO_SET_TOURNAMENT) {
+            return ["Sets: 1", "Set type: Pro set", "Super tie: No", "Score: Golden Point"];
+        }
+        if (modeId == MODE_FRIENDLY) {
+            return ["Sets: Unlimited", "Set type: Normal", "Super tie: No", "Score: Golden Point"];
+        }
+        return ["", "", "", ""];
+    }
+}
+

--- a/source/tests/testGameModes.mc
+++ b/source/tests/testGameModes.mc
@@ -1,0 +1,49 @@
+import Toybox.Lang;
+import Toybox.Test;
+
+(:test)
+function gameModes_tournamentPresetMapping(logger as Logger) as Boolean {
+    var c = GameModes.configForMode(GameModes.MODE_TOURNAMENT) as MatchConfig;
+    return c != null &&
+        c.getNumberOfSets() == 3 &&
+        c.getSetType() == MatchConfig.SET_TYPE_NORMAL &&
+        c.getSuperTie() == false &&
+        c.getPointRule() == MatchConfig.POINT_RULE_GOLDEN;
+}
+
+(:test)
+function gameModes_tournamentSuperPresetMapping(logger as Logger) as Boolean {
+    var c = GameModes.configForMode(GameModes.MODE_TOURNAMENT_SUPER) as MatchConfig;
+    return c != null &&
+        c.getNumberOfSets() == 3 &&
+        c.getSetType() == MatchConfig.SET_TYPE_NORMAL &&
+        c.getSuperTie() == true &&
+        c.getPointRule() == MatchConfig.POINT_RULE_GOLDEN;
+}
+
+(:test)
+function gameModes_proSetTournamentPresetMapping(logger as Logger) as Boolean {
+    var c = GameModes.configForMode(GameModes.MODE_PRO_SET_TOURNAMENT) as MatchConfig;
+    return c != null &&
+        c.getNumberOfSets() == 1 &&
+        c.getSetType() == MatchConfig.SET_TYPE_PRO &&
+        c.getSuperTie() == false &&
+        c.getPointRule() == MatchConfig.POINT_RULE_GOLDEN;
+}
+
+(:test)
+function gameModes_friendlyPresetMapping(logger as Logger) as Boolean {
+    var c = GameModes.configForMode(GameModes.MODE_FRIENDLY) as MatchConfig;
+    return c != null &&
+        c.getNumberOfSets() == MatchConfig.UNLIMITED_SETS &&
+        c.getSetType() == MatchConfig.SET_TYPE_NORMAL &&
+        c.getSuperTie() == false &&
+        c.getPointRule() == MatchConfig.POINT_RULE_GOLDEN;
+}
+
+(:test)
+function gameModes_customReturnsNull(logger as Logger) as Boolean {
+    var c = GameModes.configForMode(GameModes.MODE_CUSTOM);
+    return c == null;
+}
+


### PR DESCRIPTION
closes #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the old "Sets" menu with a "Game Mode" menu offering presets: Tournament, Tournament Super, Pro Set Tournament, Friendly, and Custom.
  * Preset modes auto-apply match settings (sets, set type, tie rules, scoring).
  * Added a multi-line confirmation screen summarizing the selected mode before starting a match.
  * Custom mode routes to manual set configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->